### PR TITLE
Update Gatsby to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/marked": "^4.0.8",
         "@types/react-helmet": "^6.1.0",
         "babel-preset-gatsby": "^3.3.1",
-        "gatsby": "^5.3.2",
+        "gatsby": "^5.16.1",
         "gatsby-plugin-algolia": "^1.0.2",
         "gatsby-plugin-canonical-urls": "^5.3.0",
         "gatsby-plugin-emotion": "^8.13.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/marked": "^4.0.8",
     "@types/react-helmet": "^6.1.0",
     "babel-preset-gatsby": "^3.3.1",
-    "gatsby": "^5.3.2",
+    "gatsby": "^5.16.1",
     "gatsby-plugin-algolia": "^1.0.2",
     "gatsby-plugin-canonical-urls": "^5.3.0",
     "gatsby-plugin-emotion": "^8.13.1",


### PR DESCRIPTION
# Gatsby を最新バージョンに更新

## Summary
Gatsby の devDependency 指定を npm registry の latest である `5.16.1` に合わせます。

**主な変更点:**
- `package.json` の `gatsby` を `^5.16.1` に更新
- `package-lock.json` のルート依存指定も `^5.16.1` に更新
- lockfile 上の解決済み Gatsby バージョンが `5.16.1` であることを確認

## チケットへのリンク
ここはまだない

## やったこと
- `npm view gatsby version` で latest が `5.16.1` であることを確認
- Gatsby の要求バージョンを latest に更新
- PR 差分を Gatsby 更新の 2 行に限定

## 動作確認
- [x] `npm run build`
- [x] `git diff origin/main...HEAD` で PR 差分を確認
- [x] `git merge-base --is-ancestor origin/main HEAD` で base 追従を確認

## レビュー & 動作確認 チェックリスト
- [ ] **依存バージョン** - `gatsby` の指定が `^5.16.1` になっていること
- [ ] **lockfile** - ルート依存指定が `package.json` と一致していること
- [ ] **ビルド** - Gatsby build が成功すること

**推奨テスト計画:**
1. `npm ci`
2. `npm run build`
3. 生成ページに主要ルートの欠落がないことを確認

## その他気になることや相談ごと
作業ツリーには、この PR に含めていない未コミット変更が残っています。
