### PR TITLE
Keep post links valid after build

### DIFF
--- a/src/components/shared/organisms/posts/default.tsx
+++ b/src/components/shared/organisms/posts/default.tsx
@@ -7,10 +7,9 @@ import { mq } from 'constants/index'
 import Category from '../../atoms/category'
 
 const styles = new Styles({
-  link: `
-    ${mq.md} {
-      width: 100%;
-    }
+  titleLink: `
+    color: inherit;
+    display: block;
   `,
   container: `
     display: flex;
@@ -109,31 +108,33 @@ const Post = ({ post, containerStyle }: Props) => {
   const path = blog.postShowPath(slug, language)
 
   return (
-    <Link className={styles.link} to={path}>
-      <div className={[styles.container, containerStyle].join(' ')}>
-        <div className={styles.content}>
-          <div className={styles.header}>
-            <Category category={category} language={language} />
-            <h2>{title}</h2>
-            <aside>{createdAt}</aside>
-          </div>
-          <div className={styles.footer}>
-            <ul className={styles.tags}>
-              {tags.slice(0, 3).map((item: string) => {
-                return (
-                  <li className={styles.tags} key={item}>
-                    <Link to={blog.tagPath(item, language)}>{`#${i18next.t(
-                      `tags.${item}`
-                    )}`}</Link>
-                  </li>
-                )
-              })}
-              {tags.length > 3 && <li> + {tags.length - 3}</li>}
-            </ul>
-          </div>
+    <div className={[styles.container, containerStyle].join(' ')}>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <Category category={category} language={language} />
+          <h2>
+            <Link className={styles.titleLink} to={path}>
+              {title}
+            </Link>
+          </h2>
+          <aside>{createdAt}</aside>
+        </div>
+        <div className={styles.footer}>
+          <ul className={styles.tags}>
+            {tags.slice(0, 3).map((item: string) => {
+              return (
+                <li className={styles.tags} key={item}>
+                  <Link to={blog.tagPath(item, language)}>{`#${i18next.t(
+                    `tags.${item}`
+                  )}`}</Link>
+                </li>
+              )
+            })}
+            {tags.length > 3 && <li> + {tags.length - 3}</li>}
+          </ul>
         </div>
       </div>
-    </Link>
+    </div>
   )
 }
 

--- a/src/components/shared/organisms/searchForm.tsx
+++ b/src/components/shared/organisms/searchForm.tsx
@@ -76,6 +76,11 @@ const styles = new Styles({
       font-size: 14px;
     }
 
+    h2 a {
+      color: inherit;
+      display: block;
+    }
+
     .body {
       margin: 8px 0;
     }
@@ -196,12 +201,13 @@ const SearchForm = () => {
             } = article
             return (
               <li key={article.id}>
-                <Link
-                  className={styles.card}
-                  to={blog.postShowPath(slug, language)}
-                >
+                <div className={styles.card}>
                   <p>{createdAt.slice(0, 10)}</p>
-                  <h2>{title}</h2>
+                  <h2>
+                    <Link to={blog.postShowPath(slug, language)}>
+                      {title}
+                    </Link>
+                  </h2>
                   <p className="footer">
                     {categories?.length && (
                       <ul className={styles.category}>
@@ -228,7 +234,7 @@ const SearchForm = () => {
                       )
                     })}
                   </ul>
-                </Link>
+                </div>
               </li>
             )
           })


### PR DESCRIPTION
# Build 後に記事リンクが消える問題を修正

## Summary
記事カードと検索結果カードで、記事への `Link` の内側にカテゴリ・タグなど別の `Link` が入っていました。静的 HTML build 後に nested anchor がブラウザで補正され、記事リンクが消えたように見える問題を修正します。

**主な変更点:**
- 記事一覧カードの外側リンクを廃止し、記事タイトルだけを記事リンクに変更
- 検索結果カードも同じくタイトルリンクへ変更
- カテゴリ・タグリンクと記事リンクが nested しない HTML 構造に変更

## チケットへのリンク
ここはまだない

## やったこと
- `src/components/shared/organisms/posts/default.tsx` の記事カード構造を修正
- `src/components/shared/organisms/searchForm.tsx` の検索結果カード構造を修正
- タイトルリンクの見た目が既存カードに馴染むように `color: inherit` と `display: block` を付与

## 動作確認
- [x] `npm run build`
- [x] `public/index.html` に記事タイトルの `href` が出力されることを確認
- [x] `public/index.html` / `public/posts/index.html` / `public/en/index.html` で nested anchor が検出されないことを確認

## レビュー & 動作確認 チェックリスト
- [ ] **記事タイトルリンク** - 一覧ページの記事タイトルから記事詳細へ遷移できること
- [ ] **カテゴリ・タグリンク** - カテゴリ・タグのリンクが引き続き機能すること
- [ ] **カード表示** - 一覧カードと検索結果カードの見た目が大きく崩れていないこと

**推奨テスト計画:**
1. `npm run build` を実行する
2. トップページまたは posts ページで記事タイトルをクリックして記事詳細に遷移する
3. カテゴリ・タグリンクも別リンクとしてクリックできることを確認する

## その他気になることや相談ごと
カード全体クリックは廃止し、HTML として valid なタイトルリンクへ寄せています。
