### PR TITLE
Add blog path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@ https://ver-1-0.net/
 
 My blog built in Gatsby + Netlify.
 
+## Path prefix
+
+This site is built for hosting under `/blog/`.
+
+Gatsby uses `pathPrefix: '/blog'` in `gatsby-config.ts`, and the app route metadata exposes `blog.basePath` as `/blog/` from `src/lib/routes.ts`.
+
+Use the normal build script so generated links and assets include the prefix:
+
+```sh
+npm run build
+```
+
+When previewing the production build locally, use:
+
+```sh
+npm run serve
+```

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -7,6 +7,7 @@ require('dotenv').config({
 })
 
 const config: GatsbyConfig = {
+  pathPrefix: '/blog',
   siteMetadata: {
     siteUrl: meta.siteUrl,
     title: meta.title,

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "license": "MIT",
   "scripts": {
     "clean": "gatsby clean",
-    "build": "gatsby clean && gatsby build",
+    "build": "gatsby clean && gatsby build --prefix-paths",
     "build:inspect": "npm run clean && node --inspect-brk node_modules/.bin/gatsby build",
     "develop": "gatsby develop -H 0.0.0.0",
     "develop:inspect": "yarn run clean && node --inspect-brk --no-lazy node_modules/.bin/gatsby develop",
-    "serve": "gatsby serve -H 0.0.0.0",
+    "serve": "gatsby serve -H 0.0.0.0 --prefix-paths",
     "generate": "node scripts/generator/index.js",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"{gatsby-*.js,src/**/*.js}\"",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -54,7 +54,7 @@ const monthArchivePath = (month: string, language: Lang) => {
 }
 
 export const blog = {
-  basePath: '/',
+  basePath: '/blog/',
   rootPath,
   aboutPath,
   postPath,
@@ -65,4 +65,3 @@ export const blog = {
   tagPath,
   monthArchivePath
 }
-


### PR DESCRIPTION
# Add blog path prefix

## Summary
Gatsby のビルド成果物を `/blog/` 配下で配信できるように、path prefix の設定とビルド/プレビュー手順を揃えました。

**主な変更点:**
- Gatsby config に `pathPrefix: '/blog'` を追加
- `npm run build` / `npm run serve` で `--prefix-paths` を使うように変更
- `blog.basePath` と README のドキュメントを `/blog/` 前提に更新

## チケットへのリンク
ここはまだない

## やったこと
- `gatsby-config.ts` に `/blog` の path prefix を設定
- `package.json` の build / serve script を prefix 対応
- README に `/blog/` 配下でホストする前提と確認コマンドを追記

## 動作確認
- [x] `npm run build`
- [x] 生成された `public/index.html` 内でリンク・アセットが `/blog/` prefix 付きになることを確認
- [x] `gatsby serve --prefix-paths` が現在の Gatsby CLI で有効なことを確認

## レビュー & 動作確認 チェックリスト
- [ ] **配信先の mount path** - 本番環境で `/blog/` 配下に成果物が配置されること
- [ ] **リンク生成** - ナビゲーションと画像アセットが `/blog/` 配下で解決できること
- [ ] **README** - 開発者向け手順が実際の build / serve script と一致していること

**推奨テスト計画:**
1. `npm run build` を実行する
2. `npm run serve` で production build を起動する
3. `/blog/` 配下でトップページ、記事ページ、画像アセットを確認する

## その他気になることや相談ごと
ビルド時に既存の Gatsby/Sass/SCSS module 関連 warning は出ますが、今回の変更による build failure はありません。

Notes
Requested by: user
